### PR TITLE
add namespace page so URI resolves

### DIFF
--- a/pages/pbcore/PBCoreNamespace.md
+++ b/pages/pbcore/PBCoreNamespace.md
@@ -1,0 +1,8 @@
+---
+title: PBCore Namespace
+layout: xsd
+section: Schema
+permalink: /PBCore/PBCoreNamespace
+---
+
+The PBCore namespace should be used to distinguish PBCore metadata elements and attributes from those provided and defined by other namespaces. 


### PR DESCRIPTION
I have no idea if this is what we actually want on our namespace page. Technically namespace URIs don't have to resolve to anything, but we've heard that Oxygen won't validate some PBCore xml when the URI is included in the namespace declaration and the URI doesn't resolve to anything. 