### PR TITLE
Adds links to Spannish language site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+
+WORKDIR /srv/pbcore-av-metadata
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+CMD jekyll serve --host 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.5.1'
+ruby '2.6.3'
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   1.16.5
+   1.17.3

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,12 +2,16 @@
   <meta name="viewport" content="width=device-width">
   <nav class="primary_nav_container navbar navbar-expand-xl navbar-expand-lg navbar-expand-md navbar-expand-sm navbar-expand-xs navbar-light bg-light">
 
+
+    <div class="language-selector">
+      <a href="/pbcore-av-metadata-espanol{{ page.url }}">Ver en Español</a>
+    </div>
+
     <div class="navbar-collapse" id="navbarNavDropdown">
 
       <div class="pbcore-logo" style="width: 100%;">
         <a href="/"><img class="pbcore-logo-img" src="/assets/images/pbcore-logo.png" alt=""></a>
       </div>
-
 
       <ul class="navbar-nav" style="width: 100%;">
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1221,3 +1221,14 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX*/
 .nav-underline-grey {
   border-bottom: 5px solid $dark-grey
 }
+
+.language-selector {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 1em 1em 0 0;
+
+  a {
+    font-size: 1em;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  site:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - $PWD:/srv/pbcore-av-metadata


### PR DESCRIPTION
Adds link to Spanish language site in top right corner in an absolute position.

Also, Dockerizes the development enviornment. Run `docker compose  up` from project root to start a jekyll development server, running on port 4000 by default.